### PR TITLE
Pass --noreport to tree

### DIFF
--- a/book/src/getting-started/cloning-a-repository.md
+++ b/book/src/getting-started/cloning-a-repository.md
@@ -30,7 +30,7 @@ command, `--colocate`. `jj` supports two different kinds of repositories:
 colocated, and non-colocated. What's the difference? Well, let's take a look
 at our repository:
 
-{{#trycmdinclude tests/tests/cmd/getting-started.trycmd:10:19}} 
+{{#trycmdinclude tests/tests/cmd/getting-started.trycmd:10:17}} 
 
 We have both a `.jj` and a `.git` directory at the top level. This means both
 jj's information as git's information are co-located: they're next to each
@@ -44,7 +44,7 @@ at the root of the repository will still work.
 
 Let's see what our repository's history looks like:
 
-{{#trycmdinclude tests/tests/cmd/getting-started.trycmd:22:27}} 
+{{#trycmdinclude tests/tests/cmd/getting-started.trycmd:20:25}} 
 
 This looks a bit different than `git log`, but it's the same general idea: we
 can see where we our in our history.

--- a/book/src/getting-started/interacting-with-github.md
+++ b/book/src/getting-started/interacting-with-github.md
@@ -2,7 +2,7 @@
 
 Let's take one last look at that `jj log` output:
 
-{{#trycmdinclude tests/tests/cmd/getting-started.trycmd:45:52}} 
+{{#trycmdinclude tests/tests/cmd/getting-started.trycmd:43:50}} 
 
 Do you see that little `trunk` over on the right there? That is a *bookmark*
 in `jj`, and it's how `jj` understands git branches. `trunk` is the name of
@@ -16,7 +16,7 @@ locally, but when we interact with GitHub, it needs a branch name.
 
 To create a bookmark, we can use `jj bookmark`:
 
-{{#trycmdinclude tests/tests/cmd/getting-started.trycmd:54:55}} 
+{{#trycmdinclude tests/tests/cmd/getting-started.trycmd:52:53}} 
 
 `jj bookmark create` takes a name for the bookmark, and then we also pass a `-r` flag.
 This is short for "revision," which is a sort of catch-all name for the various kinds
@@ -25,7 +25,7 @@ the change ID. In this case, we pass `@-`, which means "the parent of `@`."
 
 Let's look at our log:
 
-{{#trycmdinclude tests/tests/cmd/getting-started.trycmd:57:64}} 
+{{#trycmdinclude tests/tests/cmd/getting-started.trycmd:55:62}} 
 
 We can now see `goodbye-world` listed on the right. Great! Let's push that up
 to GitHub:

--- a/book/src/getting-started/making-a-new-change.md
+++ b/book/src/getting-started/making-a-new-change.md
@@ -7,7 +7,7 @@ simplest possible workflow. If you're a fan of building up small commits via the
 If you remember from the end of the last section, we're on an empty change.
 You can double check with `jj status` (or `jj st`):
 
-{{#trycmdinclude tests/tests/cmd/getting-started.trycmd:29:32}} 
+{{#trycmdinclude tests/tests/cmd/getting-started.trycmd:27:30}} 
 
 So what is a change, anyway? It is the core primitive you'll be working with in
 `jj`. We'll talk about that actually means in Part 2. For now, you can think of
@@ -35,7 +35,7 @@ fn main() {
 
 A bit fatalistic, but it works. Let's run `jj st` again:
 
-{{#trycmdinclude tests/tests/cmd/getting-started.trycmd:35:40}} 
+{{#trycmdinclude tests/tests/cmd/getting-started.trycmd:33:38}} 
 
 We can see we've modified `src/main.rs`. Whenever we run a `jj` command, `jj`
 will snapshot all of the changes that we've made to any files in our repository
@@ -51,14 +51,14 @@ but now I love it.
 Let's say we're happy with the contents of this change. We're done, and we want
 to start working on something else. To do that, we can use `jj commit`:
 
-{{#trycmdinclude tests/tests/cmd/getting-started.trycmd:41:43}} 
+{{#trycmdinclude tests/tests/cmd/getting-started.trycmd:39:41}} 
 
 Easy enough! Our working copy is now on a fresh new change, and its parent
 is our "Goodbye, world!" change that we just committed.
 
 To see our changes in context, let's look at `jj log` again:
 
-{{#trycmdinclude tests/tests/cmd/getting-started.trycmd:45:52}} 
+{{#trycmdinclude tests/tests/cmd/getting-started.trycmd:43:50}} 
 
 You can see that we're currently working on an empty change. It has `x` as a
 change ID, but there's also a little `@` there: `@` is an alias for the working

--- a/tests/tests/cmd/getting-started.trycmd
+++ b/tests/tests/cmd/getting-started.trycmd
@@ -9,7 +9,16 @@ Added 4 files, modified 0 files, removed 0 files
 
 $ jj config set --repo ui.color never
 
-$ tree . -a -L 1 -C
+$ tree . -a -L 1 -C --noreport
+ .
+ ├── .git
+ ├── .gitignore
+ ├── .jj
+ ├── Cargo.lock
+ ├── Cargo.toml
+ └── src
+ 
+ 3 directories, 3 files
 
 $ jj config set --repo debug.randomness-seed 12347
 


### PR DESCRIPTION
Turns out GitHub Actions is running Ubuntu 2024 LTS and I'm runing 2022 LTS. The versions of tree disagree about the number of directories present. So let's just not print those out for now, until I upgrade.